### PR TITLE
NXD-0: Update webpki due to vulnerabilities

### DIFF
--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -33,7 +33,7 @@ rustls = { version = "^0.22", optional = true }
 # rustls-pemfile is only needed for unit tests
 rustls-pemfile = { version = "2", optional = true }
 # webpki is only needed for unit tests
-webpki = { version = "0.21", optional = true }
+webpki = { version = "0.22", optional = true }
 url = "2.5.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Found by dependabot: https://github.com/nextdata-tech/nxd/security/dependabot/160
Reference: https://github.com/briansmith/webpki/issues/69